### PR TITLE
Update react version to `19.0.3`

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -29,9 +29,9 @@
     "onfido-sdk-ui": "^14.43.0",
     "prop-types": "^15.8.1",
     "qrcode.react": "^4.2.0",
-    "react": "^19.0.1",
+    "react": "^19.0.3",
     "react-bootstrap": "^2.10.10",
-    "react-dom": "^19.0.1",
+    "react-dom": "^19.0.3",
     "react-router": "^7.3.0",
     "vite": "^6.1.1",
     "vite-plugin-svgr": "^4.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,13 +57,13 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0(react@19.2.1)
       react:
-        specifier: ^19.0.1
+        specifier: ^19.0.3
         version: 19.2.1
       react-bootstrap:
         specifier: ^2.10.10
         version: 2.10.10(@types/react@19.0.10)(react-dom@19.2.1)(react@19.2.1)
       react-dom:
-        specifier: ^19.0.1
+        specifier: ^19.0.3
         version: 19.2.1(react@19.2.1)
       react-router:
         specifier: ^7.3.0


### PR DESCRIPTION
This pull request updates the minimum required versions of the `react` and `react-dom` dependencies from `19.0.1` to `19.0.3`. This is a minor version bump to ensure the project uses the latest patch release within React 19.

Dependency version updates:

* Updated the `react` dependency version from `^19.0.1` to `^19.0.3` in `package.json` and `pnpm-lock.yaml` to require the latest patch version.
* Updated the `react-dom` dependency version from `^19.0.1` to `^19.0.3` in `package.json` and `pnpm-lock.yaml` to require the latest patch version.